### PR TITLE
Set the app directory at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 /.idea
+/app/*
+/web/*

--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,10 @@
       "Silktide\\LazyBoy\\": "src",
       "Silktide\\LazyBoy\\Test\\": "test"
     }
+  },
+  "scripts": {
+    "install-lazy-boy": [
+      "Silktide\\LazyBoy\\Controller\\ScriptController::install"
+    ]
   }
 }

--- a/removeTemplates.sh
+++ b/removeTemplates.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+rm -rf app
+rm -rf web
+
+echo "template directories removed"

--- a/src/Controller/ScriptController.php
+++ b/src/Controller/ScriptController.php
@@ -48,11 +48,6 @@ class ScriptController
         }
 
         $templates = [
-            "app" => [
-                $templateDir . "/app/config/app.json.temp",
-                ["appDir" => $appDir],
-                [$appDir . "/app/config/app.json", $appDir . "/app/config/app.yaml"]
-            ],
             "routes" => [
                 $templateDir . "/app/config/routes.json.temp",
                 [],

--- a/src/templates/app/bootstrap.php.temp
+++ b/src/templates/app/bootstrap.php.temp
@@ -1,6 +1,8 @@
 <?php
 
-include_once(__DIR__ . "/../vendor/autoload.php");
+$appDir = dirname(__DIR__);
+
+include_once($appDir . "/vendor/autoload.php");
 
 use Silktide\Syringe\ReferenceResolver;
 use Silktide\Syringe\ContainerBuilder;
@@ -15,7 +17,8 @@ $loaders = [
 ];
 
 $configPaths = [
-    __DIR__ . "/config"
+    $appDir . "/app/config",
+    $appDir
 ];
 
 $builder = new ContainerBuilder($resolver, $configPaths);
@@ -23,7 +26,7 @@ $builder = new ContainerBuilder($resolver, $configPaths);
 foreach ($loaders as $loader) {
     $builder->addLoader($loader);
 }
+$builder->setApplicationRootDirectory($appDir);
 
 {{puzzleConfigLoadFiles}}
-$builder->addConfigFile("app.json");
 $builder->addConfigFile("services.json");

--- a/src/templates/app/config/app.json.temp
+++ b/src/templates/app/config/app.json.temp
@@ -1,5 +1,0 @@
-{
-  "parameters": {
-    "app.dir": "{{appDir}}"
-  }
-}

--- a/src/templates/app/console.php.temp
+++ b/src/templates/app/console.php.temp
@@ -1,8 +1,4 @@
 <?php
-/**
- * Silktide Nibbler. Copyright 2013-2014 Silktide Ltd. All Rights Reserved.
- */
-
 include_once("bootstrap.php");
 
 use Symfony\Component\Console\Application;


### PR DESCRIPTION
Including the app directory in a template does not fit with build process where the vendor scripts are packaged into the deployment. In such cases, composer is not run on the production machine, so the app directory is that of the machine that built the package.

For example, a build machine can be running under "/home/builder/application" when it runs composer, and that value would be written to the template. However, that directory probably does not exist on a production machine, which will prevent the app from working