### PR TITLE
Route security

### DIFF
--- a/src/Security/SecurityContainer.php
+++ b/src/Security/SecurityContainer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Silktide\LazyBoy\Security;
+
+/**
+ * SecurityContainer
+ */
+class SecurityContainer
+{
+
+    protected $routes = [];
+
+    protected $defaultSecurity = [];
+
+    public function __construct($defaultSecurity = [])
+    {
+        $this->defaultSecurity = $defaultSecurity;
+    }
+
+    public function setSecurityForRoute($route, $security)
+    {
+        $this->routes[$route] = $security;
+    }
+
+    public function getSecurityForRoute($route)
+    {
+        return isset($this->routes[$route])
+            ? $this->routes[$route]
+            : $this->defaultSecurity;
+    }
+
+}

--- a/src/templates/app/config/services.json.temp
+++ b/src/templates/app/config/services.json.temp
@@ -1,13 +1,22 @@
 {
   "parameters": {
-
+    "securityContainer.defaultSecurity": {
+      "public": true
+    }
   },
   "services": {
     "routeLoader": {
       "class": "Silktide\\LazyBoy\\Config\\RouteLoader",
       "arguments": [
         "@app",
+        "@securityContainer",
         ["@yaml.loader", "@json.loader"]
+      ]
+    },
+    "securityContainer": {
+      "class": "Silktide\\LazyBoy\\Security\\SecurityContainer",
+      "arguments": [
+        "%securityContainer.defaultSecurity%"
       ]
     },
     "yaml.loader": {


### PR DESCRIPTION
Allow security configuration to be set in the route config, so we can set routes as being public or private and specify the roles that are (not) allowed to use the route

This make a breaking change to the RouteLoader, so I'd recommend a new major version 