### PR TITLE
fixed issue with command verification being truthy rather than true

### DIFF
--- a/src/templates/app/console.php.temp
+++ b/src/templates/app/console.php.temp
@@ -12,7 +12,7 @@ $serviceNames = $container->keys();
 $application = new Application("CLI", "1.0.0");
 foreach ($serviceNames as $name) {
     // commands are suffixed with ".command" ...
-    if (strrpos($name, ".command") == strlen($name) - 8) {
+    if (strrpos($name, ".command") === strlen($name) - 8) {
         $command = $container[$name];
         // ... and are instances of the Symfony Command class
         if ($command instanceof Command) {


### PR DESCRIPTION
In it's current incarnation, if you feed a string without `.command` in it to strrpos, it returns false.

If the service name is 8 characters long, `strlen($name) -8` will return 0. 

(false == 0) = true using truthly, so any service that is 8 characters long would get past the check.

Not much of a concern given that there's an instanceof check below, but it's still incorrect.