### PR TITLE
CORS: allowed methods config

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ parameters:
 ```
 
 The `allowedMethods` parameters set which HTTP methods can be used with your API. You can use these to enable custom 
-methods or to set a more restricted set. The `OPTIONS` method is required for CORS to work, so it should always be an
+methods or to use a more restricted list. The `OPTIONS` method is required for CORS to work, so it should always be an
 set in these lists. As with the request headers, the list of methods and default methods are merged together, so you 
 only need to set them if you need to make changes.
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ Imported files are merged into a single configuration array before routes and gr
 conflicts arise, the latter import will overwrite the former and the importing file will take precedence over any 
 imported routes.
 
+### Configuration
+
+By default, the `RouteLoader` restricts HTTP methods to a set of the most commonly used methods: `GET`, `POST`, `PATCH`, 
+`PUT` and `DELETE`. This can be customised by changing the Syringe DI configuration value `router.allowedMethods`:
+
+```yaml
+parameters:
+    # ...
+    router.allowedMethods:
+        - "get"
+        - "post"
+        - "delete"
+        - "connect" # added CONNECT method
+        - "upsert"  # added custom / non-standard method 
+        # PUT and PATCH methods are now disabled (not present in the list)
+```
+
+Allowed method values are case insensitive
+
 ## Providers
 
 ### CORS Provider
@@ -168,18 +187,22 @@ additional headers or to restrict headers.
 
 ```yaml
 parameters:
-    cors.defaultAllowedMethods:
-# optional, automatically set to:
-#     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+    # defaults to the value of router.allowedMethods
     cors.allowedMethods:
-      - "CONNECT"
-      - "CUSTOM"
+        - "get" 
+        - "post"
+        - "put"
 ```
 
-The `allowedMethods` parameters set which HTTP methods can be used with your API. You can use these to enable custom 
-methods or to use a more restricted list. The `OPTIONS` method is required for CORS to work, so it should always be an
-set in these lists. As with the request headers, the list of methods and default methods are merged together, so you 
-only need to set them if you need to make changes.
+The `allowedMethods` parameters set which HTTP methods can be used with your API. You can use these to use a more 
+restricted list than the RouteLoader allows. In the above example, CORS requests will only be allowed for `GET`, `POST` 
+and `PUT` methods, so cross origin sources cannot make a request to `DELETE`. 
+
+The `OPTIONS` method is required for CORS to work, so is always added automatically; it is not required for it to be in 
+the configuration list
+
+Also, it should be obvious, but is worth noting that any allowed CORS methods that aren't in the `router.allowedMethods` 
+configuration list will not work as the `RouteLoader` will reject them
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,48 @@ Imported files are merged into a single configuration array before routes and gr
 conflicts arise, the latter import will overwrite the former and the importing file will take precedence over any 
 imported routes.
 
+## Providers
+
+### CORS Provider
+
+The CORS provider can be used to give your API the ability to accept cross domain requests. It is enabled by default and 
+can be configured by adding the following parameters to your app's syringe config:
+
+#### Allowed Headers
+
+```yaml
+parameters:
+    cors.request.defaultHeaders:
+# optional, automatically set to:
+#     ["Content-Type", "Authorization"]
+    cors.request.headers:
+      - "X-CUSTOM-REQUEST_HEADER"
+    cors.response.headers:
+      - "X-CUSTOM-RESPONSE-HEADER"
+```
+
+These parameters allow for additional headers to be sent and received by the client. `cors.request.defaultHeaders` 
+contains the headers commonly required by Lazy-Boy apps, but can be overwritten if these headers need to be removed. The 
+headers and defaultHeaders are merged together, so you only need to set these configuration options if you need to use
+additional headers or to restrict headers.
+
+#### Allowed Methods
+
+```yaml
+parameters:
+    cors.defaultAllowedMethods:
+# optional, automatically set to:
+#     ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+    cors.allowedMethods:
+      - "CONNECT"
+      - "CUSTOM"
+```
+
+The `allowedMethods` parameters set which HTTP methods can be used with your API. You can use these to enable custom 
+methods or to set a more restricted set. The `OPTIONS` method is required for CORS to work, so it should always be an
+set in these lists. As with the request headers, the list of methods and default methods are merged together, so you 
+only need to set them if you need to make changes.
+
 ## Contributing
 
 If you have improvements you would like to see, open an issue in this github project or better yet, fork the project,

--- a/src/Config/RouteLoader.php
+++ b/src/Config/RouteLoader.php
@@ -38,20 +38,37 @@ class RouteLoader
     /**
      * @param Application $application
      * @param SecurityContainer $securityContainer
-     * @param array|null $allowedMethods
+     * @param array $allowedMethods
      * @param array $loaders
      */
-    public function __construct(Application $application, SecurityContainer $securityContainer, array $allowedMethods, array $loaders = [])
-    {
+    public function __construct(
+        Application $application,
+        SecurityContainer $securityContainer,
+        array $allowedMethods,
+        array $loaders = []
+    ) {
         $this->application = $application;
         $this->securityContainer = $securityContainer;
-        $this->allowedMethods = array_flip($allowedMethods);
+        $this->setAllowedMethods($allowedMethods);
 
         foreach ($loaders as $loader) {
             if ($loader instanceof LoaderInterface) {
                 $this->addLoader($loader);
             }
         }
+    }
+
+    /**
+     * @param array $allowedMethods
+     */
+    protected function setAllowedMethods(array $allowedMethods)
+    {
+        $this->allowedMethods = array_flip( // flip so we can use isset()
+            array_map( // normalise values to uppercase
+                "strtoupper",
+                $allowedMethods
+            )
+        );
     }
 
     /**
@@ -106,9 +123,9 @@ class RouteLoader
                     throw new RouteException("The data for the '$routeName' route is missing required elements");
                 }
                 if (empty($config["method"])) {
-                    $config["method"] = "get";
+                    $config["method"] = "GET";
                 } else {
-                    $config["method"] = strtolower($config["method"]);
+                    $config["method"] = strtoupper($config["method"]);
                     // check method is allowed
                     if (!isset($this->allowedMethods[$config["method"]])) {
                         throw new RouteException("The method '{$config["method"]}' for route '$routeName' is not allowed");
@@ -118,7 +135,10 @@ class RouteLoader
                 /**
                  * @var Controller $controller
                  */
-                $controller = $this->application->{$config["method"]}($url, $config["action"])->bind($routeName);
+                $controller = $this->application
+                    ->match($url, $config["action"])
+                    ->method($config["method"])
+                    ->bind($routeName);
 
                 if (isset($config["assert"]) && is_array($config["assert"])) {
                     foreach ($config["assert"] as $variable => $regex) {

--- a/src/Config/RouteLoader.php
+++ b/src/Config/RouteLoader.php
@@ -18,13 +18,7 @@ class RouteLoader
     /**
      * @var array
      */
-    protected $allowedMethods = [
-        "get" => true,
-        "post" => true,
-        "put" => true,
-        "delete" => true,
-        "patch" => true
-    ];
+    protected $allowedMethods;
 
     /**
      * @var Application
@@ -44,12 +38,14 @@ class RouteLoader
     /**
      * @param Application $application
      * @param SecurityContainer $securityContainer
+     * @param array|null $allowedMethods
      * @param array $loaders
      */
-    public function __construct(Application $application, SecurityContainer $securityContainer, array $loaders=[])
+    public function __construct(Application $application, SecurityContainer $securityContainer, array $allowedMethods, array $loaders = [])
     {
         $this->application = $application;
         $this->securityContainer = $securityContainer;
+        $this->allowedMethods = array_flip($allowedMethods);
 
         foreach ($loaders as $loader) {
             if ($loader instanceof LoaderInterface) {

--- a/src/Provider/CorsServiceProvider.php
+++ b/src/Provider/CorsServiceProvider.php
@@ -23,14 +23,16 @@ class CorsServiceProvider implements ServiceProviderInterface, BootableProviderI
         $pimple["cors.request.headers"] = [];
         $pimple["cors.response.headers"] = [];
 
-        // default the cors allowed methods to what is set for the router plus the OPTIONS method
-        $pimple["cors.allowedMethods"] = array_merge($pimple["router.allowedMethods"], ["options"]);
+        // default the cors allowed methods to what is set for the router
+        $pimple["cors.allowedMethods"] = $pimple["router.allowedMethods"];
     }
 
     public function boot(Application $app) {
         $allowedResponseHeaders = $app["cors.response.headers"];
         $allowedRequestHeaders = array_merge($app["cors.request.defaultHeaders"], $app["cors.request.headers"]);
         $allowedMethods = $app["cors.allowedMethods"];
+        // The OPTIONS method is required for CORS, so add that regardless
+        $allowedMethods[] = "options";
 
         //handling CORS preflight request
         $app->before(function (Request $request) use ($allowedRequestHeaders, $allowedMethods) {

--- a/src/Provider/CorsServiceProvider.php
+++ b/src/Provider/CorsServiceProvider.php
@@ -37,7 +37,7 @@ class CorsServiceProvider implements ServiceProviderInterface, BootableProviderI
     public function boot(Application $app) {
         $allowedResponseHeaders = $app["cors.response.headers"];
         $allowedRequestHeaders = array_merge($app["cors.request.defaultHeaders"], $app["cors.request.headers"]);
-        $allowedMethods = array_merge($app["cors.response.defaultAllowedMethods"], $app["cors.response.allowedMethods"]);
+        $allowedMethods = array_merge($app["cors.defaultAllowedMethods"], $app["cors.allowedMethods"]);
 
         //handling CORS preflight request
         $app->before(function (Request $request) use ($allowedRequestHeaders, $allowedMethods) {

--- a/src/templates/app/config/services.yml.temp
+++ b/src/templates/app/config/services.yml.temp
@@ -2,6 +2,13 @@ parameters:
   securityContainer.defaultSecurity:
     public: true
 
+  router.allowedMethods:
+    - "get"
+    - "post"
+    - "put"
+    - "delete"
+    - "patch"
+
   debug: false
 
 services:
@@ -10,6 +17,7 @@ services:
     arguments:
       - "@app"
       - "@securityContainer"
+      - "%router.allowedMethods%"
       -
         - "@yaml.loader"
         - "@json.loader"

--- a/test/Config/RouteLoaderTest.php
+++ b/test/Config/RouteLoaderTest.php
@@ -48,7 +48,7 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
 
         $this->controllerCollection->shouldReceive("bind");
 
-        $loader = new RouteLoader($this->app, $this->securityContainer);
+        $loader = new RouteLoader($this->app, $this->securityContainer, ["get", "post"]);
 
         foreach ($expectedCalls as $call) {
             $this->app->shouldReceive($call["method"])->with($call["url"], $call["action"])->once()->andReturn($this->controllerCollection);
@@ -82,7 +82,7 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
         $this->app->shouldReceive("get")->andReturn($this->controllerCollection);
         $this->app->shouldReceive("post")->andReturn($this->controllerCollection);
 
-        $loader = new RouteLoader($this->app, $this->securityContainer);
+        $loader = new RouteLoader($this->app, $this->securityContainer, ["get", "post"]);
         $loader->addLoader(new JsonLoader());
         $loader->addLoader(new YamlLoader());
 
@@ -456,7 +456,7 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
         $this->app->shouldReceive("post")->withArgs([$overrideUrl, \Mockery::any()])->atLeast()->once()->andReturn($this->controllerCollection);
 
         // create the loader and run the test
-        $loader = new RouteLoader($this->app, $this->securityContainer);
+        $loader = new RouteLoader($this->app, $this->securityContainer, ["get", "post"]);
         $loader->addLoader(new JsonLoader());
 
         $loader->parseRoutes($routesFile);
@@ -481,4 +481,3 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
     }
 
 }
- 

--- a/test/Config/RouteLoaderTest.php
+++ b/test/Config/RouteLoaderTest.php
@@ -2,9 +2,12 @@
 
 namespace Silktide\LazyBoy\Test\Config;
 
+use Mockery\Mock;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
+use Silex\ControllerCollection;
+use Silex\Route;
 use Silktide\LazyBoy\Config\RouteLoader;
 use Silktide\LazyBoy\Exception\RouteException;
 use Silex\Application;
@@ -15,20 +18,28 @@ use Silktide\LazyBoy\Security\SecurityContainer;
 class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var \Mockery\Mock|Application
+     * @var Application|Mock
      */
     protected $app;
 
     /**
-     * @var \Mockery\Mock|SecurityContainer
+     * @var SecurityContainer|Mock
      */
     protected $securityContainer;
 
-    /** @var \Mockery\Mock $controllerCollection */
+    /**
+     * @var ControllerCollection|Mock $controllerCollection
+     */
     protected $controllerCollection;
+
+    /**
+     * @var Route|Mock
+     */
+    protected $route;
 
     public function setUp()
     {
+        $this->route = \Mockery::mock("Silex\\Route");
         $this->controllerCollection = \Mockery::mock("Silex\\ContainerCollection");
         $this->app = \Mockery::mock("Silex\\Application");
         $this->securityContainer = \Mockery::mock("Silktide\\LazyBoy\\Security\\SecurityContainer");
@@ -51,7 +62,8 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
         $loader = new RouteLoader($this->app, $this->securityContainer, ["get", "post"]);
 
         foreach ($expectedCalls as $call) {
-            $this->app->shouldReceive($call["method"])->with($call["url"], $call["action"])->once()->andReturn($this->controllerCollection);
+            $this->app->shouldReceive("match")->with($call["url"], $call["action"])->once()->andReturn($this->route);
+            $this->route->shouldReceive("method")->with(strtoupper($call["method"]))->once()->andReturn($this->controllerCollection);
         }
 
         try {
@@ -79,8 +91,9 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
             ++$counts[$routeName];
         });
 
-        $this->app->shouldReceive("get")->andReturn($this->controllerCollection);
-        $this->app->shouldReceive("post")->andReturn($this->controllerCollection);
+        $this->app->shouldReceive("match")->andReturn($this->route);
+        $this->route->shouldReceive("method")->with("GET")->andReturn($this->controllerCollection);
+        $this->route->shouldReceive("method")->with("POST")->andReturn($this->controllerCollection);
 
         $loader = new RouteLoader($this->app, $this->securityContainer, ["get", "post"]);
         $loader->addLoader(new JsonLoader());
@@ -451,9 +464,13 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase {
             ++$counts[$routeName];
         });
 
-        $this->app->shouldReceive("get")->andReturn($this->controllerCollection);
+        $this->route->shouldReceive("method")->with("GET")->andReturn($this->controllerCollection);
+        $this->route->shouldReceive("method")->with("POST")->atLeast()->once()->andReturn($this->controllerCollection);
         // add check to make sure the overridden route uses the correct version (from the "root"-most file)
-        $this->app->shouldReceive("post")->withArgs([$overrideUrl, \Mockery::any()])->atLeast()->once()->andReturn($this->controllerCollection);
+        $this->app->shouldReceive("match")->withArgs([$overrideUrl, \Mockery::any()])->atLeast()->once()->andReturn($this->route);
+
+        // add default expectation for match last, so it doesn't interfere with the more specific expectation above
+        $this->app->shouldReceive("match")->andReturn($this->route);
 
         // create the loader and run the test
         $loader = new RouteLoader($this->app, $this->securityContainer, ["get", "post"]);


### PR DESCRIPTION
Fixes #21 
Add ability to configure the HTTP methods that can be used with a Lazy-Boy API