### PR TITLE
Custom templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ following to your composer file:
 
 ```json
 "extra": {
-  "lazy-boy": {
+  "silktide/lazy-boy": {
     "prevent-install": true
   }
 }

--- a/src/Controller/ScriptController.php
+++ b/src/Controller/ScriptController.php
@@ -140,6 +140,7 @@ class ScriptController implements PluginInterface, EventSubscriberInterface
                     ];
                     break;
 
+                // TODO: Deprecated usage. This should be removed when the doctrine-wrapper registers its template through composer
                 case "silktide/doctrine-wrapper":
                     $templates["doctrine"] = [
                         $templateDir . "/cli-config.php.temp",

--- a/src/Controller/ScriptController.php
+++ b/src/Controller/ScriptController.php
@@ -37,7 +37,10 @@ class ScriptController implements PluginInterface, EventSubscriberInterface
         $composer = $event->getComposer();
         $package = $composer->getPackage();
         $extra = $package->getExtra();
-        if (!empty($extra["lazy-boy"]["prevent-install"])) {
+        if (
+            !empty($extra["lazy-boy"]["prevent-install"]) ||
+            !empty($extra["silktide/lazy-boy"]["prevent-install"])
+        ) {
             return;
         }
 


### PR DESCRIPTION
This one probably warrants some discussion

The idea is to allow other libraries to register templates to be generated by lazy-boy. This works by configuring the library's composer file to specify the names and locations of the templates and the output files they should result in.

I have included a security mechanism to white-list packages that are allowed to do this, so that libraries don't randomly start generating or overwriting files unexpectedly.

Let me know if you think of any other problems