### PR TITLE
Fix ErrorException when overriding templates

### DIFF
--- a/src/Controller/ScriptController.php
+++ b/src/Controller/ScriptController.php
@@ -191,7 +191,7 @@ class ScriptController implements PluginInterface, EventSubscriberInterface
                     }
 
                     $outputFile = $config["output"];
-                    if (strpos($outputFile, $appDir) === false) {
+                    if (is_string($outputFile) && strpos($outputFile, $appDir) === false) {
                         $outputFile = $appDir . "/" . ltrim($outputFile, "/");
                     }
 

--- a/src/Controller/ScriptController.php
+++ b/src/Controller/ScriptController.php
@@ -222,8 +222,13 @@ class ScriptController implements PluginInterface, EventSubscriberInterface
 
     }
 
-    protected static function processTemplate($templateFilePath, array $replacements = [], array $outputFilePaths = [], IOInterface $output)
+    protected static function processTemplate($templateFilePath, array $replacements = [], $outputFilePaths, IOInterface $output)
     {
+
+        if (!is_array($outputFilePaths)) {
+            $outputFilePaths = [$outputFilePaths];
+        }
+
         foreach ($outputFilePaths as $file) {
             // If any of the output file exists, DO NOT overwrite it
             if (file_exists($file)) {


### PR DESCRIPTION
The "services" and "routes" templates have an array of output files, in order to prevent installing a yml file when you already have a json one.

When overriding these templates, if the "output" field is omitted an ErrorException is thrown when checking if the output path is absolute. 

This fix makes sure all paths are absolute, whether they are a single path or an array of paths.